### PR TITLE
Updated 0bytes.md to include hints about nonextisting folders or insufficient permissions

### DIFF
--- a/source/dav/0bytes.md
+++ b/source/dav/0bytes.md
@@ -63,6 +63,9 @@ exist, SabreDAV itself will create an empty file at that location.
 So this is another situation where an empty file may be created before the
 _actual_ file comes in.
 
+Another reason might be, that the lock-file could not be created due to a nonexisting folder or insuficient permissions.
+Check your logfiles for errors.
+
 What if there is no follow-up PUT?
 ----------------------------------
 


### PR DESCRIPTION
I've added one more reason why the 0byte error can occur.
Its the case that I was seeing when setting up sabre/dav on ubuntu 16.04 with PHP7.0.
