### PR TITLE
Upgraded minimal PHP version requirement

### DIFF
--- a/source/baikal/install.md
+++ b/source/baikal/install.md
@@ -9,7 +9,7 @@ Requirements
 
 Baikal requires:
 
-* PHP 5.5
+* PHP 7.2+
 * MySQL or SQLite
 * Apache or Nginx
 


### PR DESCRIPTION
Support for PHP 5.x was removed with Baikal release 0.6.0.
As PHP 7.1 will only get security fixes for another 3 months, I'd suggest we set PHP 7.2 as minimal requirement.