### PR TITLE
Small updates to "install.md": change owner of "config" dir, too

### DIFF
--- a/source/baikal/install.md
+++ b/source/baikal/install.md
@@ -19,10 +19,10 @@ Installation instructions
 To install Baïkal, download the latest zip file from the [releases page on github][1].
 After downloading the file, unpack it and upload it to your server.
 
-After uploading, you _must_ make sure that the `Specific` directory is writeable by
-your webserver process. This might mean that you need to give 'world-write' access
-via your FTP client, or maybe that you run `chown www-data:www-data Specific` on
-a console.
+After uploading, you _must_ make sure that the `Specific` and the `config` directories
+are writeable by your webserver process. This might mean that you need to give
+'world-write' access via your FTP client, or maybe that you run 
+`chown -R www-data:www-data Specific config` on a console.
 
 After that step has been completed, you can access the installer by browsing to
 


### PR DESCRIPTION
I am installing Baikal version 0.7.1 with the instructions in file. But only changing the owner of the "Specific" directory did brings up this error message in my browser:

> In order to work properly, Baïkal needs to have write permissions in the Specific/ and config/ folder.

So, I guess, the installation instructions should also advise to change the owner of the "config" directory.

And since "Specific" has a subfolder "db", I would recommend to use the `-R` option with `chown`, to do the changes recursively.