### PR TITLE
update doc references for lighttpd and nginx

### DIFF
--- a/source/dav/clients/transmit.md
+++ b/source/dav/clients/transmit.md
@@ -26,7 +26,7 @@ Chunked Request Body problem
 
 Transmit suffers from the same issue as the OS/X client, where it sends all
 HTTP PUT requests as 'Chunked' transfer encoding. This is not supported by
-many servers, such as lighttpd and nginx, as well as using apache + fastcgi.
+older versions of lighttpd and nginx, or by apache + fastcgi.
 
 If you plan to support Transmit you are strongly advised to just use
 apache + mod_php.

--- a/source/dav/webservers.md
+++ b/source/dav/webservers.md
@@ -93,9 +93,7 @@ Nginx versions 1.3.9 or higher should work.
 Lighttpd
 --------
 
-Using lighttpd is generally not recommended. Development has been incredibly
-slow in recent years, and lighttpd does not have support for many required
-HTTP methods, such as `MKCALENDAR`, `MKCOL`, `ACL`, etc.
+lighttpd versions 1.4.44 or higher should work.
 
 IIS
 ---


### PR DESCRIPTION
update doc references for lighttpd and nginx.  The doc references are many years out-of-date.

lighttpd is actively developed and has supported PUT with `Transfer-Encoding: chunked` since lighttpd 1.4.44, released Dec 2016