### PR TITLE
Updating documentation for configuring MacOS 10.14 "Mojave" Calendar.…

### DIFF
--- a/source/dav/clients/ical.md
+++ b/source/dav/clients/ical.md
@@ -137,6 +137,10 @@ After finding the calendar-home-url, the following is requested for calendars:
 
 More details to follow
 
+### 10.14 "Mojave" with `Calendar.app` v11.0
+
+Under OS X 10.14 "Mojave", configuration with a `Server Path` of `/baikal/html/dav.php/principals/<username>` worked to successfully configure `Calendar.app` (version 11.0) with Baikal 0.9.2.  Note that https:// seems to be required in order for `Calendar.app` to successfully send credentials.
+
 ### Bugs
 
 #### Assuming scheduling support

--- a/source/dav/clients/osx-addressbook.md
+++ b/source/dav/clients/osx-addressbook.md
@@ -80,6 +80,8 @@ CalDAV server, but I've also had cases where:
 Even after trying this, it seems to randomly forget the correct TCP port and
 default back to 8008 (which is the standard port for Darwin Calendar Server).
 
+Under OS X 10.14 "Mojave", configuration with a `Server Path` of `/baikal/html/dav.php/principals/` worked to successfully configure `Contacts.app` (version 12.0) with Baikal 0.9.2.  Note that https:// seems to be required in order for `Contacts.app` to successfully send credentials.
+
 ### Single addressbook
 
 **Affects: OS X 10.6 until OS X 10.10**


### PR DESCRIPTION
…app and Contacts.app DAV clients with Baikal.

I spent several hours yesterday working to get Baikal successfully working with Calendar.app and Contacts.app in MacOS 10.14 "Mojave", combing through GitHub tickets and elsewhere.  Hopefully this helps future Baikal+MacOS users get setup quickly.